### PR TITLE
Convert PropTypes.object to use ThemeSchema

### DIFF
--- a/app/renderer/src/components/App.js
+++ b/app/renderer/src/components/App.js
@@ -1,7 +1,8 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
 import { compose, style } from 'glamor';
 import QueryFieldContainer from '../containers/QueryFieldContainer';
 import ResultListContainer from '../containers/ResultListContainer';
+import { ThemeSchema } from '../schema';
 
 const base = style({
   backgroundColor: '#f2f2f2',
@@ -34,7 +35,7 @@ App.defaultProps = {
 };
 
 App.propTypes = {
-  theme: PropTypes.object,
+  theme: ThemeSchema,
 };
 
 export default App;

--- a/app/renderer/src/components/QueryField.js
+++ b/app/renderer/src/components/QueryField.js
@@ -1,5 +1,6 @@
 import React, { Component, PropTypes } from 'react';
 import { compose, style } from 'glamor';
+import { ThemeSchema } from '../schema';
 
 const base = style({
   padding: 15,
@@ -40,7 +41,7 @@ const QueryField = class extends Component {
 
 QueryField.propTypes = {
   onChange: PropTypes.func,
-  theme: PropTypes.object,
+  theme: ThemeSchema,
   value: PropTypes.string,
 };
 

--- a/app/renderer/src/components/ResultItem.js
+++ b/app/renderer/src/components/ResultItem.js
@@ -1,7 +1,7 @@
 import React, { PropTypes } from 'react';
 import { style, compose, hover } from 'glamor';
 import Icon from './Icon';
-import ResultItemSchema from '../schema/ResultItemSchema';
+import { ResultItemSchema, ThemeSchema } from '../schema';
 
 const activeStyle = {
   backgroundColor: '#3f93fe',
@@ -81,7 +81,7 @@ const ResultItem = ({ theme, selected, item, onDoubleClick }) => {
 };
 
 ResultItem.propTypes = {
-  theme: PropTypes.object,
+  theme: ThemeSchema,
   // item prop should follow the Alfred workflow script filter JSON format
   // https://www.alfredapp.com/help/workflows/inputs/script-filter/json/
   item: ResultItemSchema,

--- a/app/renderer/src/components/ResultList.js
+++ b/app/renderer/src/components/ResultList.js
@@ -1,7 +1,7 @@
 import React, { PropTypes } from 'react';
 import { pseudo, style, compose } from 'glamor';
 import ResultItemContainer from '../containers/ResultItemContainer';
-import ResultItemSchema from '../schema/ResultItemSchema';
+import { ResultItemSchema, ThemeSchema } from '../schema';
 
 const base = compose(
   style({
@@ -41,7 +41,7 @@ const ResultList = props => {
 };
 
 ResultList.propTypes = {
-  theme: PropTypes.object,
+  theme: ThemeSchema,
   results: PropTypes.arrayOf(ResultItemSchema),
   selectedIndex: PropTypes.number,
 };

--- a/app/renderer/src/containers/AppContainer.js
+++ b/app/renderer/src/containers/AppContainer.js
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import App from '../components/App';
 import * as actionCreators from '../actions/creators';
+import { ThemeSchema } from '../schema';
 import {
   IPC_WINDOW_RESIZE,
   IPC_LOAD_THEME,
@@ -44,7 +45,7 @@ AppContainer.defaultProps = {
 };
 
 AppContainer.propTypes = {
-  theme: PropTypes.object,
+  theme: ThemeSchema,
   setTheme: PropTypes.func,
 };
 

--- a/app/renderer/src/containers/QueryFieldContainer.js
+++ b/app/renderer/src/containers/QueryFieldContainer.js
@@ -4,6 +4,7 @@ import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import QueryField from '../components/QueryField';
 import * as actionCreators from '../actions/creators';
+import { ThemeSchema } from '../schema';
 import {
   IPC_WINDOW_SHOW,
   IPC_WINDOW_HIDE,
@@ -65,7 +66,7 @@ QueryFieldContainer.defaultProps = {
 };
 
 QueryFieldContainer.propTypes = {
-  theme: PropTypes.object,
+  theme: ThemeSchema,
   q: PropTypes.string,
   updateQuery: PropTypes.func,
   resetQuery: PropTypes.func,

--- a/app/renderer/src/containers/ResultItemContainer.js
+++ b/app/renderer/src/containers/ResultItemContainer.js
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import * as actionCreators from '../actions/creators';
 import ResultItem from '../components/ResultItem';
-import ResultItemSchema from '../schema/ResultItemSchema';
+import { ThemeSchema, ResultItemSchema } from '../schema';
 import {
   IPC_EXECUTE_ITEM,
 } from '../../../ipc';
@@ -38,8 +38,12 @@ const ResultItemContainer = class extends Component {
   }
 };
 
+ResultItemContainer.defaultProps = {
+  theme: {},
+};
+
 ResultItemContainer.propTypes = {
-  theme: PropTypes.object,
+  theme: ThemeSchema,
   // item prop should follow the Alfred workflow script filter JSON format
   // https://www.alfredapp.com/help/workflows/inputs/script-filter/json/
   action: PropTypes.string,

--- a/app/renderer/src/containers/ResultListContainer.js
+++ b/app/renderer/src/containers/ResultListContainer.js
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import * as actionCreators from '../actions/creators';
 import ResultList from '../components/ResultList';
-import ResultItemSchema from '../schema/ResultItemSchema';
+import { ResultItemSchema, ThemeSchema } from '../schema';
 import {
   IPC_WINDOW_RESIZE,
   IPC_QUERY_RESULTS,
@@ -77,7 +77,7 @@ ResultListContainer.defaultProps = {
 };
 
 ResultListContainer.propTypes = {
-  theme: PropTypes.object,
+  theme: ThemeSchema,
   results: PropTypes.arrayOf(ResultItemSchema),
   selectedIndex: PropTypes.number,
   selectItem: PropTypes.func,

--- a/app/renderer/src/schema/index.js
+++ b/app/renderer/src/schema/index.js
@@ -1,0 +1,7 @@
+import ResultItemSchema from './ResultItemSchema';
+import ThemeSchema from './ThemeSchema';
+
+export default {
+  ResultItemSchema,
+  ThemeSchema,
+};


### PR DESCRIPTION
This PR add `ThemeSchema` as the shape to be applied on the `theme` prop.
atm, this addresses `containers/*`, but we can continue with applying this rule on `components/*` too if necessary