### PR TITLE
Ensure that state-management is consistent

### DIFF
--- a/app/renderer/src/reducers/q.js
+++ b/app/renderer/src/reducers/q.js
@@ -7,7 +7,7 @@ export default function (state = initialState, action) {
     case UPDATE_QUERY:
       return action.q;
     case RESET_QUERY:
-      return state;
+      return '';
     default:
       return state;
   }

--- a/app/renderer/src/reducers/selectedIndex.js
+++ b/app/renderer/src/reducers/selectedIndex.js
@@ -11,7 +11,7 @@ export default function (state = initialState, action) {
     case SELECT_NEXT_ITEM:
       return state + 1;
     case SELECT_PREVIOUS_ITEM:
-      if (state === 0 || state === 1) {
+      if (state <= 1) {
         return 0;
       }
       return state - 1;


### PR DESCRIPTION
in `q.js`:
We want to ensure that the `state` we return is truly `''` when the actionType is `RESET_QUERY`

in `selectedIndex.js`:
Just rewrote it to use a short hand