### PR TITLE
feature: Support for copy to clipboard

### DIFF
--- a/app/main/index.js
+++ b/app/main/index.js
@@ -1,5 +1,7 @@
 const path = require('path');
 const electron = require('electron');
+
+const { clipboard } = electron;
 const {
   loadPlugins,
   queryResults,
@@ -56,6 +58,9 @@ const execute = message => {
       if (message.item.arg) {
         shell.openExternal(message.item.arg);
       }
+      break;
+    case 'copy':
+      clipboard.writeText(message.item.arg);
       break;
     default:
       // do nothing

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -77,6 +77,22 @@ module.exports = {
 };
 ```
 
+### Plugin options
+
+#### `keyword`
+
+the starting phrase in the input to target your specific plugin to execute the commands.
+
+#### `action`
+
+value     | description
+---       | ---
+`openurl` | Opens an external URL
+`copy`    | Copies the value of `arg` of the selected item
+
+
+---
+
 ## Item Schema
 
 ### title


### PR DESCRIPTION
This PR adds the feature to support for plugins to copy their values to clipboard upon execution.

I added documentation on the keys that I could explain sufficiently, as well which is why I left out `helpers` and `execute`
