### PR TITLE
fix plugin query filters

### DIFF
--- a/app/main/index.js
+++ b/app/main/index.js
@@ -175,22 +175,33 @@ const handleQueryCommand = (evt, { q: queryPhrase }, plugins) => {
   // if plugins are found with the current keyword
   // only make queries to those plugins
   if (matchedPlugins.length) {
-    // if no args are set, query for helper items
-    if (!queryString.length) {
-      matchedPlugins.forEach(plugin => {
+    matchedPlugins.forEach(plugin => {
+      let doHelper = false;
+      let doResults = false;
+      if (plugin.isCore) {
+        doHelper = true;
+        doResults = true;
+      } else if (queryString.length) {
+        // if it's a community plugin,
+        // query for results if the queryString is defined
+        // otherwise, query for helper
+        doResults = true;
+      } else {
+        doHelper = true;
+      }
+      if (doHelper) {
         results.push(queryHelper(plugin, keyword));
-      });
-    } else {
-      // otherwise, make a regular query
-      matchedPlugins.forEach(plugin => {
+      }
+      if (doResults) {
+        // otherwise, make a regular query
         results.push(queryResults(plugin, args));
-      });
-    }
+      }
+    });
   } else {
     // otherwise, do a regular query to core plugins
     plugins.forEach(plugin => {
-      // if core, then just apply the output method
-      if (plugin.isCore) {
+      // if core, then query the results
+      if (plugin.isCore && (!plugin.keyword || keyword === plugin.keyword)) {
         results.push(queryResults(plugin, fractions));
       }
     });

--- a/app/main/index.js
+++ b/app/main/index.js
@@ -176,24 +176,12 @@ const handleQueryCommand = (evt, { q: queryPhrase }, plugins) => {
   // only make queries to those plugins
   if (matchedPlugins.length) {
     matchedPlugins.forEach(plugin => {
-      let doHelper = false;
-      let doResults = false;
-      if (plugin.isCore) {
-        doHelper = true;
-        doResults = true;
-      } else if (queryString.length) {
-        // if it's a community plugin,
-        // query for results if the queryString is defined
-        // otherwise, query for helper
-        doResults = true;
-      } else {
-        doHelper = true;
-      }
-      if (doHelper) {
+      // query helper only if the query string isn't set
+      if (!queryString.length) {
         results.push(queryHelper(plugin, keyword));
       }
-      if (doResults) {
-        // otherwise, make a regular query
+      // query results if it's a core plugin or has a query string
+      if (plugin.isCore || queryString.length) {
         results.push(queryResults(plugin, args));
       }
     });

--- a/app/main/plugins.js
+++ b/app/main/plugins.js
@@ -198,7 +198,6 @@ exports.connectItems = (items, plugin) => items.map(i => {
  */
 exports.queryResults = (plugin, args) => new Promise(resolve => {
   const query = args.join(' ');
-
   // process based on the schema
   switch (plugin.schema) {
     case 'alfred': {

--- a/resources/plugins/screensaver/index.js
+++ b/resources/plugins/screensaver/index.js
@@ -2,6 +2,7 @@
 
 module.exports = {
   action: 'exec',
+  keyword: 'screensaver',
   execute: {
     items: [
       {


### PR DESCRIPTION
This fixes the issue where core plugins weren't being filtered correctly.

Core plugins should be queried only when the `keyword` is excluded or if the `keyword` matches the `query`.