### PR TITLE
Feature/alt commands

### DIFF
--- a/__tests__/app/renderer/src/reducers/keys.js
+++ b/__tests__/app/renderer/src/reducers/keys.js
@@ -1,0 +1,28 @@
+import keys from '../../../../../app/renderer/src/reducers/keys';
+import * as types from '../../../../../app/renderer/src/actions/types';
+
+describe('keys reducer', () => {
+  it('should return the intial state', () => {
+    const state = [];
+    const action = {};
+    expect(keys(state, action)).toEqual([]);
+  });
+
+  it('should handle SET_ACTIVE_KEY', () => {
+    const state = [];
+    const action = { type: types.SET_ACTIVE_KEY, key: 'alt' };
+    expect(keys(state, action)).toEqual(['alt']);
+  });
+
+  it('should handle CLEAR_ACTIVE_KEY', () => {
+    const state = ['alt'];
+    const action = { type: types.CLEAR_ACTIVE_KEY, key: 'alt' };
+    expect(keys(state, action)).toEqual([]);
+  });
+
+  it('should handle CLEAR_ACTIVE_KEY (invalid)', () => {
+    const state = ['alt'];
+    const action = { type: types.CLEAR_ACTIVE_KEY, key: 'foo' };
+    expect(keys(state, action)).toEqual(['alt']);
+  });
+});

--- a/app/main/index.js
+++ b/app/main/index.js
@@ -57,14 +57,10 @@ const toggleMainWindow = () => {
 };
 
 const execute = (message) => {
-  let arg = message.item.arg;
-
   // apply modifiers if necessary
-  if (message.isMetaMod) {
-    arg = message.item.mods && message.item.mods.cmd && message.item.mods.cmd.arg;
-  } else if (message.isAltMod) {
-    arg = message.item.mods && message.item.mods.alt && message.item.mods.alt.arg;
-  }
+  const arg = (message.isMetaMod && message.item.mods && message.item.mods.cmd && message.item.mods.cmd.arg)
+    || (message.isAltMod && message.item.mods && message.item.mods.alt && message.item.mods.alt.arg)
+    || message.item.arg;
 
   switch (message.action) {
     case 'openurl':

--- a/app/main/index.js
+++ b/app/main/index.js
@@ -58,7 +58,7 @@ const toggleMainWindow = () => {
 
 const execute = (message) => {
   // apply modifiers if necessary
-  const arg = (message.isMetaMod && message.item.mods && message.item.mods.cmd && message.item.mods.cmd.arg)
+  const arg = (message.isSuperMod && message.item.mods && message.item.mods.cmd && message.item.mods.cmd.arg)
     || (message.isAltMod && message.item.mods && message.item.mods.alt && message.item.mods.alt.arg)
     || message.item.arg;
 

--- a/app/main/index.js
+++ b/app/main/index.js
@@ -57,15 +57,24 @@ const toggleMainWindow = () => {
 };
 
 const execute = (message) => {
+  let arg = message.item.arg;
+
+  // apply modifiers if necessary
+  if (message.isMetaMod) {
+    arg = message.item.mods && message.item.mods.cmd && message.item.mods.cmd.arg;
+  } else if (message.isAltMod) {
+    arg = message.item.mods && message.item.mods.alt && message.item.mods.alt.arg;
+  }
+
   switch (message.action) {
     case 'openurl':
-      if (message.item.arg) {
-        shell.openExternal(message.item.arg);
+      if (arg) {
+        shell.openExternal(arg);
       }
       break;
     case 'exec':
-      if (message.item.arg) {
-        spawn('node', [message.item.arg], { cwd: message.item.plugin.path });
+      if (arg) {
+        spawn('node', [arg], { cwd: message.item.plugin.path });
       }
       break;
     default:
@@ -112,6 +121,8 @@ const handleWindowShow = () => {
   globalShortcut.register('up', selectPreviousItem);
   globalShortcut.register('down', selectNextItem);
   globalShortcut.register('enter', executeCurrentItem);
+  globalShortcut.register('alt+enter', executeCurrentItem);
+  globalShortcut.register('super+enter', executeCurrentItem);
   globalShortcut.register('escape', hideWindow);
   globalShortcut.register('cmd+c', copyItem);
   win.webContents.send(IPC_WINDOW_SHOW);
@@ -121,6 +132,8 @@ const handleWindowHide = () => {
   globalShortcut.unregister('up');
   globalShortcut.unregister('down');
   globalShortcut.unregister('enter');
+  globalShortcut.unregister('alt+enter');
+  globalShortcut.unregister('super+enter');
   globalShortcut.unregister('escape');
   globalShortcut.unregister('cmd+c');
   win.webContents.send(IPC_WINDOW_HIDE);

--- a/app/renderer/src/actions/creators.js
+++ b/app/renderer/src/actions/creators.js
@@ -20,6 +20,7 @@ import {
  * Updates the query value
  *
  * @param {String} q - The command query
+ * @return {Object}
  */
 export function updateQuery(q) {
   return { type: UPDATE_QUERY, q };
@@ -27,6 +28,8 @@ export function updateQuery(q) {
 
 /**
  * Resets the query value
+ *
+ * @return {Object}
  */
 export function resetQuery() {
   return { type: RESET_QUERY };
@@ -36,6 +39,7 @@ export function resetQuery() {
  * Updates the results
  *
  * @param {Object[]} results - The results array
+ * @return {Object}
  */
 export function updateResults(results) {
   return { type: UPDATE_RESULTS, results };
@@ -43,6 +47,8 @@ export function updateResults(results) {
 
 /**
  * Resets the results
+ *
+ * @return {Object}
  */
 export function resetResults() {
   return { type: RESET_RESULTS };
@@ -50,6 +56,8 @@ export function resetResults() {
 
 /**
  * Resets the selected item
+ *
+ * @return {Object}
  */
 export function resetSelectedItem() {
   return { type: RESET_SELECTED_ITEM };
@@ -60,6 +68,7 @@ export function resetSelectedItem() {
  *
  * @param {Number} index
  * @param {Object} item
+ * @return {Object}
  */
 export function selectItem(index, item) {
   return { type: SELECT_ITEM, index, item };
@@ -67,6 +76,8 @@ export function selectItem(index, item) {
 
 /**
  * Selects the previous item
+ *
+ * @return {Object}
  */
 export function selectPreviousItem() {
   return { type: SELECT_PREVIOUS_ITEM };
@@ -74,6 +85,8 @@ export function selectPreviousItem() {
 
 /**
  * Selects the next item
+ *
+ * @return {Object}
  */
 export function selectNextItem() {
   return { type: SELECT_NEXT_ITEM };
@@ -83,6 +96,7 @@ export function selectNextItem() {
  * Sets the theme
  *
  * @param {Object} theme
+ * @return {Object}
  */
 export function setTheme(theme) {
   return { type: SET_THEME, theme };
@@ -92,6 +106,7 @@ export function setTheme(theme) {
  * Sets the details pane content
  *
  * @param {String} value
+ * @return {Object}
  */
 export function setDetails(value) {
   return { type: SET_DETAILS, value };
@@ -99,6 +114,8 @@ export function setDetails(value) {
 
 /**
  * Resets the details pane content
+ *
+ * @return {Object}
  */
 export function resetDetails() {
   return { type: RESET_DETAILS };
@@ -106,6 +123,8 @@ export function resetDetails() {
 
 /**
  * Closes the details pane
+ *
+ * @return {Object}
  */
 export function closeDetails() {
   return { type: CLOSE_DETAILS };
@@ -113,6 +132,8 @@ export function closeDetails() {
 
 /**
  * Opens the details pane
+ *
+ * @return {Object}
  */
 export function openDetails() {
   return { type: OPEN_DETAILS };
@@ -122,6 +143,7 @@ export function openDetails() {
  * Sets the active key
  *
  * @param {String} key
+ * @return {Object}
  */
 export function setActiveKey(key) {
   return { type: SET_ACTIVE_KEY, key };
@@ -129,6 +151,9 @@ export function setActiveKey(key) {
 
 /**
  * Clears the active key
+ *
+ * @param {String} key
+ * @return {Object}
  */
 export function clearActiveKey(key) {
   return { type: CLEAR_ACTIVE_KEY, key };

--- a/app/renderer/src/actions/creators.js
+++ b/app/renderer/src/actions/creators.js
@@ -12,6 +12,8 @@ import {
   RESET_DETAILS,
   CLOSE_DETAILS,
   OPEN_DETAILS,
+  SET_ACTIVE_KEY,
+  CLEAR_ACTIVE_KEY,
 } from './types';
 
 /**
@@ -114,4 +116,20 @@ export function closeDetails() {
  */
 export function openDetails() {
   return { type: OPEN_DETAILS };
+}
+
+/**
+ * Sets the active key
+ *
+ * @param {String} key
+ */
+export function setActiveKey(key) {
+  return { type: SET_ACTIVE_KEY, key };
+}
+
+/**
+ * Clears the active key
+ */
+export function clearActiveKey(key) {
+  return { type: CLEAR_ACTIVE_KEY, key };
 }

--- a/app/renderer/src/actions/types.js
+++ b/app/renderer/src/actions/types.js
@@ -11,3 +11,5 @@ export const SET_DETAILS = 'SET_DETAILS';
 export const RESET_DETAILS = 'RESET_DETAILS';
 export const CLOSE_DETAILS = 'CLOSE_DETAILS';
 export const OPEN_DETAILS = 'OPEN_DETAILS';
+export const SET_ACTIVE_KEY = 'SET_ACTIVE_KEY';
+export const CLEAR_ACTIVE_KEY = 'CLEAR_ACTIVE_KEY';

--- a/app/renderer/src/components/ResultItem.js
+++ b/app/renderer/src/components/ResultItem.js
@@ -56,7 +56,7 @@ const subtitle = style({
   WebkitLineClamp: 1,
 });
 
-const ResultItem = ({ theme, selected, item, isAltMod, isMetaMod, onDoubleClick }) => {
+const ResultItem = ({ theme, selected, item, isAltMod, isSuperMod, onDoubleClick }) => {
   const themeBase = style(theme.result || {});
   const themeHover = hover(theme.resultActive || {});
 
@@ -68,7 +68,7 @@ const ResultItem = ({ theme, selected, item, isAltMod, isMetaMod, onDoubleClick 
     : {};
 
   // apply modifiers if necessary
-  const itemSubtitle = (isMetaMod && item.mods && item.mods.cmd && item.mods.cmd.subtitle)
+  const itemSubtitle = (isSuperMod && item.mods && item.mods.cmd && item.mods.cmd.subtitle)
     || (isAltMod && item.mods && item.mods.alt && item.mods.alt.subtitle)
     || item.subtitle;
 
@@ -92,7 +92,7 @@ ResultItem.propTypes = {
   item: ResultItemSchema,
   selected: PropTypes.bool,
   isAltMod: PropTypes.bool,
-  isMetaMod: PropTypes.bool,
+  isSuperMod: PropTypes.bool,
   onDoubleClick: PropTypes.func,
 };
 

--- a/app/renderer/src/components/ResultItem.js
+++ b/app/renderer/src/components/ResultItem.js
@@ -56,7 +56,7 @@ const subtitle = style({
   WebkitLineClamp: 1,
 });
 
-const ResultItem = ({ theme, selected, item, onDoubleClick }) => {
+const ResultItem = ({ theme, selected, item, isAltMod, isMetaMod, onDoubleClick }) => {
   const themeBase = style(theme.result || {});
   const themeHover = hover(theme.resultActive || {});
 
@@ -67,6 +67,15 @@ const ResultItem = ({ theme, selected, item, onDoubleClick }) => {
     )
     : {};
 
+  let itemSubtitle = item.subtitle;
+
+  // apply modifiers if necessary
+  if (isMetaMod) {
+    itemSubtitle = item.mods && item.mods.cmd && item.mods.cmd.subtitle;
+  } else if (isAltMod) {
+    itemSubtitle = item.mods && item.mods.alt && item.mods.alt.subtitle;
+  }
+
   return (
     <li {...compose(base, themeBase, themeHover, themeSelected)} onDoubleClick={onDoubleClick}>
       <div {...icon}>
@@ -74,7 +83,7 @@ const ResultItem = ({ theme, selected, item, onDoubleClick }) => {
       </div>
       <div {...details}>
         <h2 {...compose(title, theme.resultTitle || {})}>{item.title}</h2>
-        <h3 {...compose(subtitle, theme.resultSubtitle || {})}>{item.subtitle}</h3>
+        <h3 {...compose(subtitle, theme.resultSubtitle || {})}>{itemSubtitle}</h3>
       </div>
     </li>
   );
@@ -86,6 +95,8 @@ ResultItem.propTypes = {
   // https://www.alfredapp.com/help/workflows/inputs/script-filter/json/
   item: ResultItemSchema,
   selected: PropTypes.bool,
+  isAltMod: PropTypes.bool,
+  isMetaMod: PropTypes.bool,
   onDoubleClick: PropTypes.func,
 };
 

--- a/app/renderer/src/components/ResultItem.js
+++ b/app/renderer/src/components/ResultItem.js
@@ -67,14 +67,10 @@ const ResultItem = ({ theme, selected, item, isAltMod, isMetaMod, onDoubleClick 
     )
     : {};
 
-  let itemSubtitle = item.subtitle;
-
   // apply modifiers if necessary
-  if (isMetaMod) {
-    itemSubtitle = item.mods && item.mods.cmd && item.mods.cmd.subtitle;
-  } else if (isAltMod) {
-    itemSubtitle = item.mods && item.mods.alt && item.mods.alt.subtitle;
-  }
+  const itemSubtitle = (isMetaMod && item.mods && item.mods.cmd && item.mods.cmd.subtitle)
+    || (isAltMod && item.mods && item.mods.alt && item.mods.alt.subtitle)
+    || item.subtitle;
 
   return (
     <li {...compose(base, themeBase, themeHover, themeSelected)} onDoubleClick={onDoubleClick}>

--- a/app/renderer/src/containers/ResultItemContainer.js
+++ b/app/renderer/src/containers/ResultItemContainer.js
@@ -19,20 +19,35 @@ const ResultItemContainer = class extends Component {
     this.execute();
   }
 
+  isAltMod() {
+    return this.props.selected && this.props.keys && this.props.keys.indexOf('alt') > -1;
+  }
+
+  isMetaMod() {
+    return this.props.selected && this.props.keys && this.props.keys.indexOf('meta') > -1;
+  }
+
   execute() {
     const { item } = this.props;
     const { action } = item;
-    ipcRenderer.send(IPC_EXECUTE_ITEM, { action, item });
+    ipcRenderer.send(IPC_EXECUTE_ITEM, {
+      action,
+      item,
+      isAltMod: this.isAltMod(),
+      isMetaMod: this.isMetaMod(),
+    });
   }
 
   render() {
-    const { theme, item, selected } = this.props;
+    const { theme, item, selected, keys } = this.props;
     return (
       <ResultItem
         theme={theme}
         item={item}
         selected={selected}
         onDoubleClick={this.handleDoubleClick}
+        isAltMod={this.isAltMod()}
+        isMetaMod={this.isMetaMod()}
       />
     );
   }
@@ -48,8 +63,13 @@ ResultItemContainer.propTypes = {
   // https://www.alfredapp.com/help/workflows/inputs/script-filter/json/
   item: ResultItemSchema,
   selected: PropTypes.bool,
+  keys: PropTypes.array,
 };
+
+const mapStateToProps = state => ({
+  keys: state.keys,
+});
 
 const mapDispatchToProps = dispatch => bindActionCreators(actionCreators, dispatch);
 
-export default connect(null, mapDispatchToProps)(ResultItemContainer);
+export default connect(mapStateToProps, mapDispatchToProps)(ResultItemContainer);

--- a/app/renderer/src/containers/ResultItemContainer.js
+++ b/app/renderer/src/containers/ResultItemContainer.js
@@ -39,7 +39,7 @@ const ResultItemContainer = class extends Component {
   }
 
   render() {
-    const { theme, item, selected, keys } = this.props;
+    const { theme, item, selected } = this.props;
     return (
       <ResultItem
         theme={theme}
@@ -63,7 +63,7 @@ ResultItemContainer.propTypes = {
   // https://www.alfredapp.com/help/workflows/inputs/script-filter/json/
   item: ResultItemSchema,
   selected: PropTypes.bool,
-  keys: PropTypes.array,
+  keys: PropTypes.arrayOf(PropTypes.string),
 };
 
 const mapStateToProps = state => ({

--- a/app/renderer/src/containers/ResultItemContainer.js
+++ b/app/renderer/src/containers/ResultItemContainer.js
@@ -66,9 +66,7 @@ ResultItemContainer.propTypes = {
   keys: PropTypes.arrayOf(PropTypes.string),
 };
 
-const mapStateToProps = state => ({
-  keys: state.keys,
-});
+const mapStateToProps = ({ key }) => ({ key });
 
 const mapDispatchToProps = dispatch => bindActionCreators(actionCreators, dispatch);
 

--- a/app/renderer/src/containers/ResultItemContainer.js
+++ b/app/renderer/src/containers/ResultItemContainer.js
@@ -23,7 +23,7 @@ const ResultItemContainer = class extends Component {
     return this.props.selected && this.props.keys && this.props.keys.indexOf('alt') > -1;
   }
 
-  isMetaMod() {
+  isSuperMod() {
     return this.props.selected && this.props.keys && this.props.keys.indexOf('meta') > -1;
   }
 
@@ -34,7 +34,7 @@ const ResultItemContainer = class extends Component {
       action,
       item,
       isAltMod: this.isAltMod(),
-      isMetaMod: this.isMetaMod(),
+      isSuperMod: this.isSuperMod(),
     });
   }
 
@@ -47,7 +47,7 @@ const ResultItemContainer = class extends Component {
         selected={selected}
         onDoubleClick={this.handleDoubleClick}
         isAltMod={this.isAltMod()}
-        isMetaMod={this.isMetaMod()}
+        isSuperMod={this.isSuperMod()}
       />
     );
   }

--- a/app/renderer/src/containers/ResultListContainer.js
+++ b/app/renderer/src/containers/ResultListContainer.js
@@ -1,3 +1,5 @@
+/* global window */
+
 import { ipcRenderer } from 'electron';
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
@@ -174,20 +176,20 @@ ResultListContainer.defaultProps = {
   updateResults: () => { },
   resetResults: () => { },
   setActiveKey: () => {},
-  clearActiveKeys: () => {},
+  clearActiveKey: () => {},
 };
 
 ResultListContainer.propTypes = {
   theme: ThemeSchema,
-  keys: PropTypes.array,
+  keys: PropTypes.arrayOf(PropTypes.string),
   results: PropTypes.arrayOf(ResultItemSchema),
   selectedIndex: PropTypes.number,
   selectNextItem: PropTypes.func,
   selectPreviousItem: PropTypes.func,
   updateResults: PropTypes.func,
   resetResults: PropTypes.func,
-  setActiveKeys: PropTypes.func,
-  clearActiveKeys: PropTypes.func,
+  setActiveKey: PropTypes.func,
+  clearActiveKey: PropTypes.func,
 };
 
 const mapStateToProps = state => ({

--- a/app/renderer/src/containers/ResultListContainer.js
+++ b/app/renderer/src/containers/ResultListContainer.js
@@ -73,25 +73,11 @@ const ResultListContainer = class extends Component {
   }
 
   handleKeyDown(e) {
-    switch (e.key.toLowerCase()) {
-      case 'alt':
-        this.props.setActiveKey('alt');
-        break;
-      case 'meta':
-        this.props.setActiveKey('meta');
-        break;
-    }
+    this.props.setActiveKey(e.key.toLowerCase());
   }
 
   handleKeyUp(e) {
-    switch (e.key.toLowerCase()) {
-      case 'alt':
-        this.props.clearActiveKey('alt');
-        break;
-      case 'meta':
-        this.props.clearActiveKey('meta');
-        break;
-    }
+    this.props.clearActiveKey(e.key.toLowerCase());
   }
 
   /**

--- a/app/renderer/src/containers/ResultListContainer.js
+++ b/app/renderer/src/containers/ResultListContainer.js
@@ -103,7 +103,7 @@ const ResultListContainer = class extends Component {
     return this.props.keys && this.props.keys.indexOf('alt') > -1;
   }
 
-  isMetaMod() {
+  isSuperMod() {
     return this.props.keys && this.props.keys.indexOf('meta') > -1;
   }
 
@@ -118,7 +118,7 @@ const ResultListContainer = class extends Component {
       action,
       item,
       isAltMod: this.isAltMod(),
-      isMetaMod: this.isMetaMod(),
+      isSuperMod: this.isSuperMod(),
     });
   }
 

--- a/app/renderer/src/reducers/index.js
+++ b/app/renderer/src/reducers/index.js
@@ -3,6 +3,7 @@ import theme from './theme';
 import q from './q';
 import results from './results';
 import selectedIndex from './selectedIndex';
+import keys from './keys';
 import detailsPane from './detailsPane';
 import detailsPaneExpanded from './detailsPaneExpanded';
 
@@ -10,7 +11,8 @@ export default combineReducers({
   theme,
   q,
   results,
+  selectedIndex,
+  keys,
   detailsPane,
   detailsPaneExpanded,
-  selectedIndex,
 });

--- a/app/renderer/src/reducers/keys.js
+++ b/app/renderer/src/reducers/keys.js
@@ -1,0 +1,17 @@
+import { SET_ACTIVE_KEY, CLEAR_ACTIVE_KEY } from '../actions/types';
+
+const initialState = [];
+
+export default function (state = initialState, action) {
+  switch (action.type) {
+    case SET_ACTIVE_KEY:
+      return state.concat([action.key]);
+    case CLEAR_ACTIVE_KEY:
+      return [
+        ...state.slice(0, state.indexOf(action.key)),
+        ...state.slice(state.indexOf(action.key) + 1),
+      ];
+    default:
+      return state;
+  }
+}


### PR DESCRIPTION
This PR adds the ability to have alternate commands mentioned in issue #23.

Priority of commands:
 - <kbd>super</kbd> + <kbd>enter</kbd> (<kbd>cmd</kbd> for macOS; <kbd>win</kbd> for Windows/Linux)
 - <kbd>alt</kbd> + <kbd>enter</kbd>
 - <kbd>enter</kbd>

## Example

```
// single item
{
  title: 'Foo',
  subtitle: 'Foobar',
  arg: 'http://foobar.com',
  mods: {
    alt: {
      arg: 'http://google.com',
      subtitle: 'Visit Google',
    },
    cmd: {
      arg: 'http://facebook.com',
      subtitle: 'Visit Facebook',
    },
  },
}
```

## Notes

- `mods.cmd` is specified instead of `super` to comply with existing Alfred plugins.