### PR TITLE
change branch to develop on readme badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Dext
 
-[![Build Status](https://travis-ci.org/vutran/dext.svg?branch=master)](https://travis-ci.org/vutran/dext) [![Coverage Status](https://coveralls.io/repos/github/vutran/dext/badge.svg?branch=master)](https://coveralls.io/github/vutran/dext?branch=master) [![Join the chat at https://gitter.im/dext-app/Lobby](https://badges.gitter.im/dext-app/Lobby.svg)](https://gitter.im/dext-app/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Build Status](https://travis-ci.org/vutran/dext.svg?branch=develop)](https://travis-ci.org/vutran/dext) [![Coverage Status](https://coveralls.io/repos/github/vutran/dext/badge.svg?branch=develop)](https://coveralls.io/github/vutran/dext?branch=develop) [![Join the chat at https://gitter.im/dext-app/Lobby](https://badges.gitter.im/dext-app/Lobby.svg)](https://gitter.im/dext-app/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 > A smart launcher for Mac. Powered by JavaScript.
 


### PR DESCRIPTION
This PR updates the branch on the readme badges to `develop` as it is the default branch for PR.