### PR TITLE
Allow trimming of trailing whitespace in `.md` files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,7 +8,3 @@ indent_size = 2
 indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
-
-# .md files shouldn't trim trailing whitespace
-[*.{md}]
-trim_trailing_whitespace = false


### PR DESCRIPTION
Resolves #75 