### PR TITLE
refactor(query): Use query as the new query command, refs #52

### DIFF
--- a/__tests__/resources/plugins/about/index.js
+++ b/__tests__/resources/plugins/about/index.js
@@ -2,12 +2,12 @@ import m from '../../../../resources/plugins/about';
 
 describe('calculator', () => {
   it('should return something', () => {
-    const results = m.execute('?');
+    const results = m.query('?');
     expect(results.items.length).toBeGreaterThan(0);
   });
 
   it('should return nothing', () => {
-    const results = m.execute('');
+    const results = m.query('');
     expect(results.items.length).not.toBeGreaterThan(0);
   });
 });

--- a/__tests__/resources/plugins/bookmarks/index.js
+++ b/__tests__/resources/plugins/bookmarks/index.js
@@ -32,13 +32,13 @@ describe('bookmarks', () => {
   ]);
 
   it('should return something with options supplied', async () => {
-    const data = await m.execute('GitHub', { size: 20 });
+    const data = await m.query('GitHub', { size: 20 });
     expect(data.items.length).toBeGreaterThan(0);
     expect(data.items[0].title).toBe('GitHub');
   });
 
   it('should return something with missing options', async () => {
-    const data = await m.execute('Github');
+    const data = await m.query('Github');
     expect(data.items.length).toBeGreaterThan(0);
     expect(data.items[0].title).toBe('GitHub');
   });
@@ -46,7 +46,7 @@ describe('bookmarks', () => {
   it('should retrieve no bookmarks', async () => {
     // eslint-disable-next-line global-require, no-underscore-dangle
     require('browser-bookmarks').__setBookmarks([]);
-    const data = await m.execute('abc');
+    const data = await m.query('abc');
     expect(data.items.length).not.toBeGreaterThan(0);
   });
 });

--- a/__tests__/resources/plugins/calculator/index.js
+++ b/__tests__/resources/plugins/calculator/index.js
@@ -6,7 +6,7 @@ describe('calculator', () => {
   it('should return 4', () => {
     // eslint-disable-next-line global-require, no-underscore-dangle
     require('mathjs').__setReturnValue('4');
-    const results = m.execute('2 + 2');
+    const results = m.query('2 + 2');
     expect(results.items[0].title).toBe('4');
     expect(results.items[0].subtitle).toBe('2 + 2');
   });
@@ -14,7 +14,7 @@ describe('calculator', () => {
   it('should throw an error', () => {
     // eslint-disable-next-line global-require, no-underscore-dangle
     require('mathjs').__setThrowError(true);
-    const results = m.execute('abc');
+    const results = m.query('abc');
     expect(results.items).toEqual([]);
   });
 });

--- a/app/main/index.js
+++ b/app/main/index.js
@@ -325,15 +325,30 @@ const createWindow = () => {
   const registerIpcListeners = (plugins) => {
     // listen to query commands and queries
     // for results and sends it to the renderer
-    ipcMain.on(IPC_QUERY_COMMAND, (evt, message) => debounceHandleQueryCommand(evt, message, plugins));
+    ipcMain.on(
+      IPC_QUERY_COMMAND,
+      (evt, message) => debounceHandleQueryCommand(evt, message, plugins)
+    );
+
     // listen for execution commands
-    ipcMain.on(IPC_EXECUTE_ITEM, (evt, message) => {
-      execute(message);
-    });
+    ipcMain.on(
+      IPC_EXECUTE_ITEM,
+      (evt, message) => {
+        execute(message);
+      }
+    );
+
     // listen for item details requests
-    ipcMain.on(IPC_ITEM_DETAILS_REQUEST, (evt, item) => debounceHandleItemDetailsRequest(evt, item));
+    ipcMain.on(
+      IPC_ITEM_DETAILS_REQUEST,
+      (evt, item) => debounceHandleItemDetailsRequest(evt, item)
+    );
+
     // copies to clipboard
-    ipcMain.on(IPC_COPY_CURRENT_ITEM, (evt, item) => debounceHandleCopyItemToClipboard(evt, item));
+    ipcMain.on(
+      IPC_COPY_CURRENT_ITEM,
+      (evt, item) => debounceHandleCopyItemToClipboard(evt, item)
+    );
   };
 
   // load all plugins (core and user) and

--- a/resources/plugins/about/index.js
+++ b/resources/plugins/about/index.js
@@ -3,7 +3,7 @@
 
 module.exports = {
   action: 'openurl',
-  execute: query => {
+  query: query => {
     let items = [];
     if (query === '?') {
       items = [

--- a/resources/plugins/bookmarks/index.js
+++ b/resources/plugins/bookmarks/index.js
@@ -18,7 +18,7 @@ const mapDextItem = item => ({
 
 module.exports = {
   action: 'openurl',
-  execute: (query, options = { size: 20 }) => new Promise(resolve => {
+  query: (query, options = { size: 20 }) => new Promise(resolve => {
     const { size } = options;
     browserBookmarks.getChrome().then(bookmarks => {
       // resolve and exist if there's no bookmarks

--- a/resources/plugins/calculator/index.js
+++ b/resources/plugins/calculator/index.js
@@ -4,7 +4,7 @@ const math = require('mathjs');
 
 module.exports = {
   action: 'openurl',
-  execute: query => {
+  query: query => {
     try {
       const ans = math.eval(query);
       const items = [];

--- a/resources/plugins/screensaver/index.js
+++ b/resources/plugins/screensaver/index.js
@@ -3,7 +3,7 @@
 module.exports = {
   action: 'exec',
   keyword: 'screensaver',
-  execute: {
+  query: {
     items: [
       {
         title: 'Screen Saver',


### PR DESCRIPTION
### NB, this introduces breaking changes

This PR changes the query command from `query` to `execute`, refs #52 

__coverage__ went down due new code that checks on outdated plugins