### PR TITLE
add fs mock

### DIFF
--- a/__mocks__/fs.js
+++ b/__mocks__/fs.js
@@ -1,0 +1,48 @@
+const fs = {};
+
+let mockFiles = [];
+let mockFileData = '';
+
+/**
+ * Sets the mock return value for fs.readdir
+ *
+ * @param {String[]} files - An array of files
+ */
+ // eslint-disable-next-line no-underscore-dangle
+fs.__setFiles = (files) => {
+  mockFiles = files;
+};
+
+/**
+ * Sets the file data for fs.readFile
+ *
+ * @param {String} data
+ */
+// eslint-disable-next-line no-underscore-dangle
+fs.__setFileData = (data) => {
+  mockFileData = data;
+};
+
+/**
+ * Reads the directory and apply the callback
+ * with the mocked values
+ *
+ * @param {String} directory
+ * @param {Function} callback
+ */
+fs.readdir = (directory, callback) => {
+  callback.call(null, null, mockFiles);
+};
+
+/**
+ * Reads the file and apply the callback
+ * with the mocked data
+ *
+ * @param {String} file
+ * @param {Function} callback
+ */
+fs.readFile = (file, callback) => {
+  callback.call(null, null, mockFileData);
+};
+
+module.exports = fs;


### PR DESCRIPTION
Adds the `fs` mock for use in #65 .

Usage:

```js
jest.mock('fs');


describe('blah', () => {
  it('should do something', () => {
    require('fs').__setFiles([ // for fs.readdir
      '/foo/bar',
      '/foo/baz',
    ]);
    require('fs').__setFileData('{"foo": "bar"}'); // for fs.readFile

    // call your func that uses fs....
    // ...
  });
});
```