### PR TITLE
fork plugin script as child process

### DIFF
--- a/app/main/index.js
+++ b/app/main/index.js
@@ -1,6 +1,6 @@
 require('string_score');
 const path = require('path');
-const { spawn } = require('child_process');
+const { fork } = require('child_process');
 const electron = require('electron');
 const {
   loadPlugins,
@@ -70,7 +70,7 @@ const execute = (message) => {
       break;
     case 'exec':
       if (arg) {
-        spawn('node', [arg], { cwd: message.item.plugin.path });
+        fork(arg, { cwd: message.item.plugin.path });
       }
       break;
     default:


### PR DESCRIPTION
Main process should be forked when trying to execute a plugin script since some user may not have a node binary installed.