### PR TITLE
cleanup test and linting

### DIFF
--- a/__tests__/app/ipc.js
+++ b/__tests__/app/ipc.js
@@ -1,5 +1,7 @@
 import ipc from '../../app/ipc';
 
-test('retrieve all ipc constants', () => {
-  expect(Object.keys(ipc).length).toBeGreaterThan(1);
+describe('ipc', () => {
+  it('should retrieve all ipc constants', () => {
+    expect(Object.keys(ipc).length).toBeGreaterThan(1);
+  });
 });

--- a/__tests__/app/main/plugins.js
+++ b/__tests__/app/main/plugins.js
@@ -2,163 +2,193 @@ import path from 'path';
 import plugins from '../../../app/main/plugins';
 import paths from '../../../utils/paths';
 
-it('should retrieve a list of core plugin paths', async () => {
-  const list = await plugins.loadPluginsInPath({
-    path: paths.CORE_PLUGIN_PATH,
-    isCore: true,
+describe('core plugins', () => {
+  it('should retrieve a list of core plugin paths', async () => {
+    const list = await plugins.loadPluginsInPath({
+      path: paths.CORE_PLUGIN_PATH,
+      isCore: true,
+    });
+    expect(list.length).toBeGreaterThan(0);
+    expect(list).toContainEqual(path.resolve(paths.CORE_PLUGIN_PATH, 'about'));
   });
-  expect(list.length).toBeGreaterThan(0);
-  expect(list).toContainEqual(path.resolve(paths.CORE_PLUGIN_PATH, 'about'));
+
+  it('should be a core plugin', () => {
+    const directory = path.resolve(paths.CORE_PLUGIN_PATH, 'core-plugin');
+    expect(plugins.isCorePlugin(directory)).toBe(true);
+  });
+
+  it('should not be a core plugin', () => {
+    const directory = path.resolve(paths.PLUGIN_PATH, 'user-plugin');
+    expect(plugins.isCorePlugin(directory)).not.toBe(true);
+  });
+
+  it('should load all core plugins', async () => {
+    // load core plugins
+    const results = await plugins.loadPlugins([
+      { path: paths.CORE_PLUGIN_PATH, isCore: true },
+    ]);
+    expect(results.length).toBeGreaterThan(0);
+    expect(results.filter(p => p.name === 'about')).toBeTruthy();
+  });
 });
 
-it('should be a core plugin', () => {
-  const directory = path.resolve(paths.CORE_PLUGIN_PATH, 'core-plugin');
-  expect(plugins.isCorePlugin(directory)).toBe(true);
+describe('theme plugins', () => {
+  it('should be a theme plugin', () => {
+    // TODO
+  });
+
+  it('should not be a theme plugin', () => {
+    // TODO
+  });
 });
 
-it('should not be a core plugin', () => {
-  const directory = path.resolve(paths.PLUGIN_PATH, 'user-plugin');
-  expect(plugins.isCorePlugin(directory)).not.toBe(true);
-});
+describe('plugin metadata', () => {
+  it('should apply module properties', () => {
+    // TODO
+  });
 
-it('should be a theme plugin', () => {
-  // TODO
-});
-
-it('should not be a theme plugin', () => {
-  // TODO
-});
-
-it('should apply module properties', () => {
-  // TODO
-});
-
-it('should load all core plugins', async () => {
-  // load core plugins
-  const results = await plugins.loadPlugins([
-    { path: paths.CORE_PLUGIN_PATH, isCore: true },
-  ]);
-  expect(results.length).toBeGreaterThan(0);
-  expect(results.filter(p => p.name === 'about')).toBeTruthy();
-});
-
-it('should apply additional meta data to a items', () => {
-  const items = [
-    {
-      title: 'Foo',
-      subtitle: 'Bar',
-      icon: {
-        path: './icon.png',
+  it('should apply additional meta data to a items', () => {
+    const items = [
+      {
+        title: 'Foo',
+        subtitle: 'Bar',
+        icon: {
+          path: './icon.png',
+        },
       },
-    },
-  ];
-  const plugin = {
-    path: '/path/to/plugin/',
-    name: 'foobar',
-    keyword: 'foo',
-    action: 'openurl',
-  };
-  const connectedItems = plugins.connectItems(items, plugin);
-  expect(connectedItems[0].icon.path).toEqual(path.resolve('/', 'path', 'to', 'plugin', 'icon.png'));
-  expect(connectedItems[0].plugin.path).toEqual('/path/to/plugin/');
-  expect(connectedItems[0].plugin.name).toEqual('foobar');
-  expect(connectedItems[0].keyword).toEqual('foo');
-  expect(connectedItems[0].action).toEqual('openurl');
+    ];
+    const plugin = {
+      path: '/path/to/plugin/',
+      name: 'foobar',
+      keyword: 'foo',
+      action: 'openurl',
+    };
+    const connectedItems = plugins.connectItems(items, plugin);
+    expect(connectedItems[0].icon.path).toEqual(path.resolve('/', 'path', 'to', 'plugin', 'icon.png'));
+    expect(connectedItems[0].plugin.path).toEqual('/path/to/plugin/');
+    expect(connectedItems[0].plugin.name).toEqual('foobar');
+    expect(connectedItems[0].keyword).toEqual('foo');
+    expect(connectedItems[0].action).toEqual('openurl');
+  });
 });
 
-it('should query for results for the given plugin', () => {
-  // TODO
+describe('plugin results', () => {
+  it('should query for results for the given plugin', () => {
+    // TODO
+  });
 });
 
-it('should query for helpers for the given plugin (Object)', async () => {
-  const plugin = {
-    name: 'foobar',
-    keyword: 'foo',
-    helper: {
+describe('plugin helper', () => {
+  it('should query for helpers for the given plugin (Object)', async () => {
+    const plugin = {
+      name: 'foobar',
+      keyword: 'foo',
+      helper: {
+        title: 'Foo',
+        subtitle: 'Bar',
+      },
+    };
+    const helperItems = await plugins.queryHelper(plugin, 'foo');
+    expect(helperItems[0].title).toEqual('Foo');
+    expect(helperItems[0].subtitle).toEqual('Bar');
+  });
+
+  it('should query for helpers for the given plugin (Function)', async () => {
+    const plugin = {
+      name: 'foobar',
+      keyword: 'foo',
+      helper: () => ({
+        title: 'Foo',
+        subtitle: 'Bar',
+      }),
+    };
+    const helperItems = await plugins.queryHelper(plugin, 'foo');
+    expect(helperItems[0].title).toEqual('Foo');
+    expect(helperItems[0].subtitle).toEqual('Bar');
+  });
+
+  it('should query for helpers for the given plugin (Promise)', async () => {
+    const plugin = {
+      name: 'foobar',
+      keyword: 'foo',
+      helper: () => new Promise(resolve => resolve({
+        title: 'Foo',
+        subtitle: 'Bar',
+      })),
+    };
+    const helperItems = await plugins.queryHelper(plugin, 'foo');
+    expect(helperItems[0].title).toEqual('Foo');
+    expect(helperItems[0].subtitle).toEqual('Bar');
+  });
+});
+
+describe('plugin details pane', () => {
+  it('should retrieve the item\'s detail pane content (String)', async () => {
+    const plugin = {
+      details: {
+        render: 'Hello, world.',
+      },
+    };
+    const item = {
       title: 'Foo',
       subtitle: 'Bar',
-    },
-  };
-  const helperItems = await plugins.queryHelper(plugin, 'foo');
-  expect(helperItems[0].title).toEqual('Foo');
-  expect(helperItems[0].subtitle).toEqual('Bar');
-});
+      plugin: {
+        path: '/path/to/plugin/__jest__',
+      },
+    };
+    const details = await plugins.retrieveItemDetails(item, plugin);
+    expect(details).toEqual('Hello, world.');
+  });
 
-it('should query for helpers for the given plugin (Function)', async () => {
-  const plugin = {
-    name: 'foobar',
-    keyword: 'foo',
-    helper: () => ({
+  it('should retrieve the item\'s detail pane content (Function)', async () => {
+    const plugin = {
+      details: {
+        render: item => `Hello, ${item.title}.`,
+      },
+    };
+    const item = {
       title: 'Foo',
       subtitle: 'Bar',
-    }),
-  };
-  const helperItems = await plugins.queryHelper(plugin, 'foo');
-  expect(helperItems[0].title).toEqual('Foo');
-  expect(helperItems[0].subtitle).toEqual('Bar');
-});
+      plugin: {
+        path: '/path/to/plugin/__jest__',
+      },
+    };
+    const details = await plugins.retrieveItemDetails(item, plugin);
+    expect(details).toEqual('Hello, Foo.');
+  });
 
-it('should query for helpers for the given plugin (Promise)', async () => {
-  const plugin = {
-    name: 'foobar',
-    keyword: 'foo',
-    helper: () => new Promise(resolve => resolve({
+  it('should retrieve the item\'s detail pane content (Promise)', async () => {
+    const plugin = {
+      details: {
+        render: item => new Promise(resolve => resolve(`Hello, ${item.title}.`)),
+      },
+    };
+    const item = {
       title: 'Foo',
       subtitle: 'Bar',
-    })),
-  };
-  const helperItems = await plugins.queryHelper(plugin, 'foo');
-  expect(helperItems[0].title).toEqual('Foo');
-  expect(helperItems[0].subtitle).toEqual('Bar');
-});
+      plugin: {
+        path: '/path/to/plugin/__jest__',
+      },
+    };
+    const details = await plugins.retrieveItemDetails(item, plugin);
+    expect(details).toEqual('Hello, Foo.');
+  });
 
-it('should retrieve the item\'s detail pane content (String)', async () => {
-  const plugin = {
-    details: {
-      render: 'Hello, world.',
-    },
-  };
-  const item = {
-    title: 'Foo',
-    subtitle: 'Bar',
-    plugin: {
-      path: '/path/to/plugin/__jest__',
-    },
-  };
-  const details = await plugins.retrieveItemDetails(item, plugin);
-  expect(details).toEqual('Hello, world.');
-});
-
-it('should retrieve the item\'s detail pane content (Function)', async () => {
-  const plugin = {
-    details: {
-      render: item => `Hello, ${item.title}.`,
-    },
-  };
-  const item = {
-    title: 'Foo',
-    subtitle: 'Bar',
-    plugin: {
-      path: '/path/to/plugin/__jest__',
-    },
-  };
-  const details = await plugins.retrieveItemDetails(item, plugin);
-  expect(details).toEqual('Hello, Foo.');
-});
-
-it('should retrieve the item\'s detail pane content (Promise)', async () => {
-  const plugin = {
-    details: {
-      render: item => new Promise(resolve => resolve(`Hello, ${item.title}.`)),
-    },
-  };
-  const item = {
-    title: 'Foo',
-    subtitle: 'Bar',
-    plugin: {
-      path: '/path/to/plugin/__jest__',
-    },
-  };
-  const details = await plugins.retrieveItemDetails(item, plugin);
-  expect(details).toEqual('Hello, Foo.');
+  it('should retrieve the item\'s details pane content as markdown', async () => {
+    const plugin = {
+      details: {
+        type: 'md',
+        render: '# hello world',
+      },
+    };
+    const item = {
+      title: 'Foo',
+      subtitle: 'Bar',
+      plugin: {
+        path: '/path/to/plugin/__jest__',
+      },
+    };
+    const details = await plugins.retrieveItemDetails(item, plugin);
+    expect(details).toEqual('<h1>hello world</h1>\n');
+  });
 });

--- a/__tests__/app/renderer/src/actions/creators.js
+++ b/__tests__/app/renderer/src/actions/creators.js
@@ -49,6 +49,15 @@ describe('action creators', () => {
     expect(actions.resetSelectedItem()).toEqual(expectedAction);
   });
 
+  it('should create an action to select an item', () => {
+    const expectedAction = {
+      type: types.SELECT_ITEM,
+      index: 1,
+      item: { foo: 'bar' },
+    };
+    expect(actions.selectItem(1, { foo: 'bar' })).toEqual(expectedAction);
+  });
+
   it('should create an action to select the previous item', () => {
     const expectedAction = {
       type: types.SELECT_PREVIOUS_ITEM,
@@ -71,6 +80,14 @@ describe('action creators', () => {
     expect(actions.setTheme('foo-theme')).toEqual(expectedAction);
   });
 
+  it('should create an action to set the details', () => {
+    const expectedAction = {
+      type: types.SET_DETAILS,
+      value: 'foobar',
+    };
+    expect(actions.setDetails('foobar')).toEqual(expectedAction);
+  });
+
   it('should create an action to reset the details', () => {
     const expectedAction = {
       type: types.RESET_DETAILS,
@@ -90,5 +107,28 @@ describe('action creators', () => {
       type: types.OPEN_DETAILS,
     };
     expect(actions.openDetails()).toEqual(expectedAction);
+  });
+
+  it('should create an action to set the active key', () => {
+    const expectedAction = {
+      type: types.SET_ACTIVE_KEY,
+      key: 'alt',
+    };
+    expect(actions.setActiveKey('alt')).toEqual(expectedAction);
+  });
+
+  it('should create an action to clear the active key', () => {
+    const expectedAction = {
+      type: types.CLEAR_ACTIVE_KEY,
+      key: 'alt',
+    };
+    expect(actions.clearActiveKey('alt')).toEqual(expectedAction);
+  });
+
+  it('should create an action to reset all keys', () => {
+    const expectedAction = {
+      type: types.RESET_KEYS,
+    };
+    expect(actions.resetKeys()).toEqual(expectedAction);
   });
 });

--- a/__tests__/app/renderer/src/components/QueryField.js
+++ b/__tests__/app/renderer/src/components/QueryField.js
@@ -19,7 +19,7 @@ describe('<QueryField /> component', () => {
 
   it('should render a query field component with some value', () => {
     const component = renderer.create(
-      <QueryField theme={theme} value={"TEST"} />
+      <QueryField theme={theme} value={'TEST'} />
     );
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();

--- a/__tests__/utils/CacheConf.js
+++ b/__tests__/utils/CacheConf.js
@@ -1,3 +1,5 @@
-test('creates a new CacheConf', () => {
-  // TODO
+describe('CacheConf', () => {
+  it('should create a new CacheConf', () => {
+    // TODO
+  });
 });

--- a/__tests__/utils/conf.js
+++ b/__tests__/utils/conf.js
@@ -1,3 +1,5 @@
-test('creates a new conf', () => {
-  // TODO
+describe('conf', () => {
+  it('should create a new conf', () => {
+    // TODO
+  });
 });

--- a/__tests__/utils/debounce.js
+++ b/__tests__/utils/debounce.js
@@ -1,15 +1,17 @@
 import helpers from '../../utils/helpers';
 
-test('debounces a function', async () => {
-  jest.useFakeTimers();
-  // create a mock function to debounce
-  const mockFn = jest.fn();
-  const debounced = helpers.debounce(mockFn, 100);
-  // shouldn't be called
-  expect(mockFn).not.toBeCalled();
-  await debounced(1);
-  // fast-forward timers
-  jest.runAllTimers();
-  // should be called
-  expect(mockFn).toBeCalled();
+describe('debounce', () => {
+  it('should debounce a function', async () => {
+    jest.useFakeTimers();
+    // create a mock function to debounce
+    const mockFn = jest.fn();
+    const debounced = helpers.debounce(mockFn, 100);
+    // shouldn't be called
+    expect(mockFn).not.toBeCalled();
+    await debounced(1);
+    // fast-forward timers
+    jest.runAllTimers();
+    // should be called
+    expect(mockFn).toBeCalled();
+  });
 });

--- a/__tests__/utils/paths.js
+++ b/__tests__/utils/paths.js
@@ -1,19 +1,21 @@
 import path from 'path';
 import paths from '../../utils/paths';
 
-test('retrieves the path to the .dext file', () => {
-  expect(path.basename(paths.DEXT_PATH)).toBe('.dext');
-});
+describe('paths', () => {
+  it('should retrieve the path to the .dext file', () => {
+    expect(path.basename(paths.DEXT_PATH)).toBe('.dext');
+  });
 
-test('retrieves the path to the theme directory', () => {
-  expect(path.basename(paths.THEME_PATH)).toBe('plugins');
-});
+  it('should retrieve the path to the theme directory', () => {
+    expect(path.basename(paths.THEME_PATH)).toBe('plugins');
+  });
 
-test('retrieves the path to the core plugins directory', () => {
-  expect(path.basename(paths.CORE_PLUGIN_PATH)).toBe('plugins');
-  expect(paths.CORE_PLUGIN_PATH).not.toBe(paths.PLUGIN_PATH);
-});
+  it('should retrieve the path to the core plugins directory', () => {
+    expect(path.basename(paths.CORE_PLUGIN_PATH)).toBe('plugins');
+    expect(paths.CORE_PLUGIN_PATH).not.toBe(paths.PLUGIN_PATH);
+  });
 
-test('retrieves the path to the user plugins directory', () => {
-  expect(path.basename(paths.PLUGIN_PATH)).toBe('plugins');
+  it('should retrieve the path to the user plugins directory', () => {
+    expect(path.basename(paths.PLUGIN_PATH)).toBe('plugins');
+  });
 });

--- a/app/main/plugins.js
+++ b/app/main/plugins.js
@@ -261,6 +261,7 @@ exports.queryResults = (plugin, args) => new Promise((resolve) => {
 
       if (output) {
         if (isDev && isOutdatedPlugin) {
+          // eslint-disable-next-line no-console
           console.log(`
             Plugin is outdated.
             Please update the plugin accordingly to the new API.

--- a/app/renderer/src/components/Icon.js
+++ b/app/renderer/src/components/Icon.js
@@ -24,7 +24,6 @@ const iconImgTextBase = compose(
 );
 
 const Icon = (props) => {
-
   const iconTextStyle = props.icon.bgColor
     ? compose(
       iconImgTextBase,

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "main": "app/main/index.js",
   "scripts": {
-    "lint": "eslint app scripts utils",
+    "lint": "eslint app scripts utils __mocks__ __tests__",
     "build": "webpack",
     "build:prod": "cross-env NODE_ENV=production webpack --config webpack.config.prod.js",
     "package": "cross-env NODE_ENV=production node scripts/package.js",
@@ -20,7 +20,7 @@
     "release": "npm run build:prod && npm run package && npm run archive",
     "dev": "cross-env NODE_ENV=development electron . --debug",
     "start": "npm run build && npm run dev",
-    "test": "jest --coverage"
+    "test": "jest --coverage --verbose"
   },
   "author": "Vu Tran <vu@vu-tran.com>",
   "repository": {

--- a/scripts/package.js
+++ b/scripts/package.js
@@ -13,7 +13,7 @@ const DEFAULT_OPTIONS = {
     '__tests__/',
     'coverage/',
     'dist/',
-    'docs/.*\.md',
+    'docs/.*.md',
     'scripts/',
     '.babelrc',
     '.DS_Store',


### PR DESCRIPTION
- Make sure all tests are grouped properly
- Move calls from the`test()` alias to `it()`
- Added some missing tests for some action creators
- Linting fixes
- Jest verbose output