### PR TITLE
fix null value in plugin config

### DIFF
--- a/app/main/plugins.js
+++ b/app/main/plugins.js
@@ -37,8 +37,10 @@ exports.loadPluginsInPath = directory => new Promise((resolve) => {
     const enabledPlugins = api.plugins.getAll();
     if (enabledPlugins.length) {
       enabledPlugins.forEach((plugin) => {
-        const pluginPath = path.resolve(directory.path, plugin);
-        loaded.push(pluginPath);
+        if (plugin) {
+          const pluginPath = path.resolve(directory.path, plugin);
+          loaded.push(pluginPath);
+        }
       });
     }
     resolve(loaded);


### PR DESCRIPTION
This PR fixes the issue where a `null` value is found in the `~/.dext/config.json` would break the plugins loader.