### PR TITLE
round down values in winPosition array

### DIFF
--- a/app/main/index.js
+++ b/app/main/index.js
@@ -60,7 +60,7 @@ const repositionWindow = () => {
     (Math.floor((currScreen.size.width / 2) - (size[0] / 2)) + currScreen.bounds.x),
     (Math.floor((currScreen.size.height / 2) - ((size[1] + resultsHeight) / 2)) + currScreen.bounds.y),
   ];
-  console.log(winPosition);
+
   win.setPosition(winPosition[0], winPosition[1]);
 };
 

--- a/app/main/index.js
+++ b/app/main/index.js
@@ -57,9 +57,10 @@ const repositionWindow = () => {
   const resultsHeight = WINDOW_MAX_HEIGHT;
   const size = win.getSize();
   const winPosition = [
-    ((currScreen.size.width / 2) - (size[0] / 2)) + currScreen.bounds.x,
-    ((currScreen.size.height / 2) - ((size[1] + resultsHeight) / 2)) + currScreen.bounds.y,
+    (Math.floor((currScreen.size.width / 2) - (size[0] / 2)) + currScreen.bounds.x),
+    (Math.floor((currScreen.size.height / 2) - ((size[1] + resultsHeight) / 2)) + currScreen.bounds.y),
   ];
+  console.log(winPosition);
   win.setPosition(winPosition[0], winPosition[1]);
 };
 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "browser-bookmarks": "^0.1.0",
     "conf": "^0.11.2",
     "deep-assign": "^2.0.0",
-    "dext-core-utils": "v0.4.1",
+    "dext-core-utils": "^0.4.1",
     "glamor": "^2.17.14",
     "is_js": "^0.9.0",
     "markdown-it": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "browser-bookmarks": "^0.1.0",
     "conf": "^0.11.2",
     "deep-assign": "^2.0.0",
-    "dext-core-utils": "^0.4.1",
+    "dext-core-utils": "v0.4.1",
     "glamor": "^2.17.14",
     "is_js": "^0.9.0",
     "markdown-it": "^8.0.1",


### PR DESCRIPTION
round down values in winPosition array so that they can work as integers for window position
see https://github.com/vutran/dext/issues/119#issuecomment-263587341

This works on Linux, hopefully doesn't break any of the other platforms.

rebased off `develop`