### PR TITLE
remove black border around dext

### DIFF
--- a/app/renderer/src/components/App.js
+++ b/app/renderer/src/components/App.js
@@ -13,8 +13,7 @@ const base = style({
   fontFamily: 'Lucida Grande, Arial, sans-serif',
   fontWeight: 'lighter',
   padding: 0,
-  width: '99%',
-  marginLeft: '3px',
+  width: '100%',
   overflow: 'hidden',
 });
 


### PR DESCRIPTION
In #119 , I described a situation that happens in Linux with a black border around dext. 
Here is a screenshot: ![Imgur](http://i.imgur.com/A6xABtR.jpg)


I found it is caused by `width: 99% `specified in `App.js`. Any reason for that value? I have put it 100% and remove the margin-left and it fixes the black border issue.

Not sure if it will have any other impacts. Please take a look.

Thank you.
