### PR TITLE
Allow plugins without keywords

### DIFF
--- a/app/main/index.js
+++ b/app/main/index.js
@@ -185,19 +185,32 @@ const handleQueryCommand = (evt, { q: queryPhrase }, plugins) => {
   const [keyword, ...args] = fractions;
   const queryString = args.join(' ').trim();
 
-  const matchedPlugins = plugins.filter(p => keyword === p.keyword);
+  const matchedPlugins = plugins.filter(p => !p.keyword || keyword === p.keyword);
 
   // if plugins are found with the current keyword
   // only make queries to those plugins
   if (matchedPlugins.length) {
     matchedPlugins.forEach((plugin) => {
-      // query helper only if the query string isn't set
-      if (!queryString.length) {
-        results.push(queryHelper(plugin, keyword));
+      let display = 'results';
+      // determine if we should display helper or query items?
+      if (plugin.keyword) {
+        if (!queryString.length) {
+          display = 'helper';
+        } else {
+          display = 'results';
+        }
       }
-      // query results if it's a core plugin or has a query string
-      if (plugin.isCore || queryString.length) {
-        results.push(queryResults(plugin, args));
+      switch (display) {
+        case 'helper':
+          results.push(queryHelper(plugin, keyword));
+          break;
+        case 'results':
+          if (!args.length) {
+            results.push(queryResults(plugin, [keyword]));
+          } else {
+            results.push(queryResults(plugin, args));
+          }
+          break;
       }
     });
   } else {

--- a/app/main/index.js
+++ b/app/main/index.js
@@ -205,8 +205,8 @@ const handleQueryCommand = (evt, { q: queryPhrase }, plugins) => {
           results.push(queryHelper(plugin, keyword));
           break;
         case 'results':
-          if (!args.length) {
-            results.push(queryResults(plugin, [keyword]));
+          if (!plugin.keyword) {
+            results.push(queryResults(plugin, fractions));
           } else {
             results.push(queryResults(plugin, args));
           }

--- a/app/main/index.js
+++ b/app/main/index.js
@@ -193,12 +193,8 @@ const handleQueryCommand = (evt, { q: queryPhrase }, plugins) => {
     matchedPlugins.forEach((plugin) => {
       let display = 'results';
       // determine if we should display helper or query items?
-      if (plugin.keyword) {
-        if (!queryString.length) {
-          display = 'helper';
-        } else {
-          display = 'results';
-        }
+      if (plugin.keyword && !queryString.length) {
+        display = 'helper';
       }
       switch (display) {
         case 'helper':


### PR DESCRIPTION
This will allow third-party plugins to have no keywords. Plugins without keywords will get queried and will have no helpers (though developers can manage their own filters within their plugin's `query` function itself).

This will allow us to proceed with external plugins for app search (#140).