### PR TITLE
allow for base64 strings for plugin icons

### DIFF
--- a/__tests__/app/main/plugins.js
+++ b/__tests__/app/main/plugins.js
@@ -70,6 +70,26 @@ describe('plugin metadata', () => {
     expect(connectedItems[0].keyword).toEqual('foo');
     expect(connectedItems[0].action).toEqual('openurl');
   });
+
+  it('should allow for base64 icons', () => {
+    const items = [
+      {
+        title: 'Foo',
+        subtitle: 'Bar',
+        icon: {
+          path: 'data:image/jpeg;base64,ABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890==',
+        },
+      },
+    ];
+    const plugin = {
+      path: '/path/to/plugin',
+      name: 'foobar',
+      keyword: 'foo',
+      action: 'openurl',
+    };
+    const connectedItems = plugins.connectItems(items, plugin);
+    expect(connectedItems[0].icon.path).toEqual('data:image/jpeg;base64,ABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890==');
+  });
 });
 
 describe('plugin results', () => {

--- a/app/main/plugins.js
+++ b/app/main/plugins.js
@@ -178,7 +178,8 @@ exports.connectItems = (items, plugin) => items.map((i) => {
   };
   if (i.icon && i.icon.path) {
     icon.path = i.icon.path;
-    if (!is.url(i.icon.path)) {
+    const isBase64 = /data\:image\/.*\;base64/.test(i.icon.path);
+    if (!is.url(i.icon.path) && !isBase64) {
       icon.path = path.resolve(plugin.path, i.icon.path);
     }
   }


### PR DESCRIPTION
This is a prerequisite for #140 (app search).

This PR will allow base64 strings for icons.