### PR TITLE
Add Darwin app

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ The ***Dext*** configuration file is located in the `.dext` folder in your home 
 
 ### Community Plugins
 
+- [dext-darwin-applications-plugin](https://github.com/vutran/dext-darwin-applications-plugin) - Dext plugin to search for applications (Darwin only).
 - [dext-docker-registry-plugin](https://github.com/vutran/dext-docker-registry-plugin) - Search the Docker Registry for images.
 - [dext-emoji-plugin](https://github.com/vutran/dext-emoji-plugin) - Search for emojis.
 - [dext-giphy-plugin](https://github.com/adnasa/dext-giphy-plugin) - Search for giphy images.


### PR DESCRIPTION
Adds a link to the Darwin apps plugin page.

First plugin to get us started for issue #130 

Link: https://github.com/vutran/dext-darwin-applications-plugin

<img width="794" alt="screenshot" src="https://cloud.githubusercontent.com/assets/1088312/21835636/5f36797c-d773-11e6-97e5-18bd6f085dc4.png">
