### PR TITLE
Hide app from dock and add context menu

### DIFF
--- a/app/main/index.js
+++ b/app/main/index.js
@@ -414,4 +414,7 @@ const onAppReady = () => {
   });
 };
 
+// hide the app from the dock and applications switcher
+app.dock.hide();
+
 app.on('ready', onAppReady);

--- a/app/main/index.js
+++ b/app/main/index.js
@@ -32,7 +32,7 @@ const Config = require('../../utils/conf');
 const CacheConf = require('../../utils/CacheConf');
 const { debounce, hasOwnProp, getOwnProp } = require('../../utils/helpers');
 const { PLUGIN_PATH } = utils.paths;
-const { app, BrowserWindow, Tray, nativeImage, clipboard, globalShortcut, ipcMain } = electron;
+const { app, BrowserWindow, Tray, Menu, nativeImage, clipboard, globalShortcut, ipcMain } = electron;
 
 // set default window values
 const WINDOW_DEFAULT_WIDTH = 700;
@@ -332,6 +332,11 @@ const createWindow = (theme) => {
   return new BrowserWindow(opts);
 };
 
+// create the Context Menu for the Tray
+const contextMenu = Menu.buildFromTemplate([
+  { label: 'Quit', type: 'normal', click: () => { app.quit(); } }
+]);
+
 /**
  * When the app is ready, creates the window,
  * register hotkeys, and loading plugins
@@ -342,7 +347,7 @@ const onAppReady = () => {
     path.resolve(__dirname, '..', '..', 'resources', 'icon.png')
   ));
 
-  tray.on('click', () => toggleMainWindow());
+  tray.setContextMenu(contextMenu)
 
   // loads the theme
   const t = config.get('theme') || '';

--- a/app/main/index.js
+++ b/app/main/index.js
@@ -334,6 +334,8 @@ const createWindow = (theme) => {
 
 // create the Context Menu for the Tray
 const contextMenu = Menu.buildFromTemplate([
+  { label: 'Toggle Dext', type: 'normal', click: () => { toggleMainWindow(); } },
+  { type: 'separator' },
   { label: 'Quit', type: 'normal', click: () => { app.quit(); } }
 ]);
 


### PR DESCRIPTION
This PR contains the changes discussed on #151.

- Hide app from dock and applications switcher
- Add Context Menu to Tray
- Add Toggle and Quit items to Context Menu