### PR TITLE
Add rubygems plugin link

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ The ***Dext*** configuration file is located in the `.dext` folder in your home 
 - [dext-npms-plugin](https://github.com/hypebeast/dext-npms-plugin) - Search for npm packages on npms.io.
 - [dext-omdb-plugin](https://github.com/adnasa/dext-omdb-plugin) - Search for imdb movies through the omdb-api.
 - [dext-base64-encode-plugin](https://github.com/brpaz/dext-base64-encode-plugin) - Dext plugin that allows to encode and decode any text into base64.
+- [dext-rubygems-plugin](https://github.com/akz92/dext-rubygems-plugin) - Search for ruby gems on rubygems.org.
 
 ### Community Themes
 - [dext-predawn-theme](https://github.com/adnasa/dext-predawn-theme) - Predawn theme for Dext


### PR DESCRIPTION
Add a plugin that searches for ruby gems on rubygems.org.

Link: https://github.com/akz92/dext-rubygems-plugin