### PR TITLE
Fix: DX: Consider using NODE_PATH #92

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,6 +7,13 @@ module.exports = {
       path.resolve(__dirname, 'app', 'renderer', 'src', 'index'),
     ],
   },
+  resolve: {
+    alias: {
+      app: path.resolve(__dirname, 'app'),
+      'dext-main': path.resolve(__dirname, 'app', 'main'),
+      'dext-renderer': path.resolve(__dirname, 'app', 'renderer', 'src'),
+    },
+  },
   output: {
     path: path.resolve(__dirname, 'app', 'renderer', 'lib'),
     filename: 'bundle.js',


### PR DESCRIPTION
Hi there,
first time contributing to an open source project.
As it was marked as `up-for-grab`, I decided to come up with this solution

Adding 3 aliases to webpack config:
1. app
    '../../../ipc'; could be now replaced with 'app/ipc'
2. dext-main
3. dext-renderer
    points to src folder