### PR TITLE
lower debounce to 150ms

### DIFF
--- a/app/main/index.js
+++ b/app/main/index.js
@@ -297,11 +297,11 @@ const handleCopyItemToClipboard = (evt, item) => {
 /**
  * Create a debounced function for handling the query command
  */
-const debounceHandleQueryCommand = debounce(handleQueryCommand, 500);
+const debounceHandleQueryCommand = debounce(handleQueryCommand, 150);
 
-const debounceHandleItemDetailsRequest = debounce(handleItemDetailsRequest, 500);
+const debounceHandleItemDetailsRequest = debounce(handleItemDetailsRequest, 150);
 
-const debounceHandleCopyItemToClipboard = debounce(handleCopyItemToClipboard, 500);
+const debounceHandleCopyItemToClipboard = debounce(handleCopyItemToClipboard, 150);
 
 /**
  * Creates a new Browser window and loads the renderer index.


### PR DESCRIPTION
0.5 second is way too long for a debounce. 150ms feels reasonable so it doesn't look like the app is slow to query.