### PR TITLE
native icon api

### DIFF
--- a/__mocks__/electron.js
+++ b/__mocks__/electron.js
@@ -1,0 +1,9 @@
+const electron = {};
+
+electron.app = {
+  getFileIcon: (path, callback) => {
+    callback(null, null);
+  },
+};
+
+module.exports = electron;

--- a/__mocks__/fs.js
+++ b/__mocks__/fs.js
@@ -89,4 +89,14 @@ fs.readFile = (file, options, callback) => {
   }
 };
 
+/**
+ * Checks for a file existance
+ *
+ * @param {String} file
+ * @return {Boolean}
+ */
+fs.existsSync = (file) => {
+  return false;
+};
+
 module.exports = fs;

--- a/__tests__/app/main/plugins.js
+++ b/__tests__/app/main/plugins.js
@@ -3,6 +3,7 @@ import { utils } from 'dext-core-utils';
 import { CORE_PLUGIN_PATH } from '../../../app/constants';
 import plugins from '../../../app/main/plugins';
 
+jest.dontMock('electron');
 jest.mock('plist');
 jest.mock('conf');
 jest.mock('fs');

--- a/app/ipc.js
+++ b/app/ipc.js
@@ -14,6 +14,8 @@ const IPC_EXECUTE_ITEM = 'execute-item';
 const IPC_ITEM_DETAILS_REQUEST = 'item-details-request';
 const IPC_ITEM_DETAILS_RESPONSE = 'item-details-response';
 const IPC_LOAD_THEME = 'load-theme';
+const IPC_FETCH_ICON = 'fetch-icon';
+const IPC_RETRIEVE_ICON = 'retrieve-icon';
 
 module.exports = {
   IPC_WINDOW_SHOW,
@@ -32,4 +34,6 @@ module.exports = {
   IPC_ITEM_DETAILS_REQUEST,
   IPC_ITEM_DETAILS_RESPONSE,
   IPC_LOAD_THEME,
+  IPC_FETCH_ICON,
+  IPC_RETRIEVE_ICON,
 };

--- a/app/main/index.js
+++ b/app/main/index.js
@@ -7,6 +7,7 @@ const {
   queryResults,
   queryHelper,
   retrieveItemDetails,
+  getFileIcon,
 } = require('./plugins');
 const { loadTheme } = require('./themes');
 const actions = require('./actions');
@@ -26,6 +27,8 @@ const {
   IPC_ITEM_DETAILS_REQUEST,
   IPC_ITEM_DETAILS_RESPONSE,
   IPC_LOAD_THEME,
+  IPC_FETCH_ICON,
+  IPC_RETRIEVE_ICON,
 } = require('../ipc');
 const { MAX_RESULTS, CORE_PLUGIN_PATH, DEBOUNCE_TIME } = require('../constants');
 const Config = require('../../utils/conf');
@@ -299,6 +302,18 @@ const handleCopyItemToClipboard = (evt, item) => {
 };
 
 /**
+ * Fetches the file icon for the given item
+ *
+ * @param {Event} evt
+ * @param {Object} item
+ */
+const fetchFileIcon = (evt, item) => {
+  getFileIcon(item).then((path) => {
+    evt.sender.send(IPC_RETRIEVE_ICON, path);
+  });
+};
+
+/**
  * Create a debounced function for handling the query command
  */
 const debounceHandleQueryCommand = debounce(handleQueryCommand, DEBOUNCE_TIME);
@@ -413,6 +428,12 @@ const onAppReady = () => {
       ipcMain.on(
         IPC_COPY_CURRENT_ITEM,
         (evt, item) => debounceHandleCopyItemToClipboard(evt, item)
+      );
+
+      // fetches the file icon
+      ipcMain.on(
+        IPC_FETCH_ICON,
+        (evt, item) => fetchFileIcon(evt, item)
       );
     };
 

--- a/app/main/plugins.js
+++ b/app/main/plugins.js
@@ -1,3 +1,4 @@
+const electron = require('electron');
 const path = require('path');
 const fs = require('fs');
 const { fork } = require('child_process');
@@ -8,6 +9,7 @@ const is = require('is_js');
 const MarkdownIt = require('markdown-it');
 const { MAX_RESULTS, IS_DEV } = require('../constants');
 
+const { app } = electron;
 const { PLUGIN_PATH } = utils.paths;
 
 /**
@@ -165,6 +167,26 @@ exports.loadPlugins = directories => new Promise((resolve, reject) => {
 });
 
 /**
+ * Retrieve the native file icon as a base64 encoded string
+ *
+ * @param {String} path - The file path
+ * @return {Promise<String>} - A base64 string representation of the file icon image
+ */
+exports.getFileIcon = (path) => new Promise((resolve, reject) => {
+  app.getFileIcon(path, (err, icon) => {
+    if (err) {
+      reject(err);
+      return;
+    }
+    if (!icon) {
+      reject('');
+      return;
+    }
+    resolve(icon.toDataURL());
+  });
+});
+
+/**
  * Connects the item sets with the given plugin
  *
  * plugin { path, name, isCore, schema, keyword, action, helper }
@@ -175,6 +197,7 @@ exports.loadPlugins = directories => new Promise((resolve, reject) => {
  */
 exports.connectItems = (items, plugin) => items.map((i) => {
   const icon = {
+    type: i.icon.type,
     path: '',
   };
   if (i.icon && i.icon.path) {

--- a/app/main/plugins.js
+++ b/app/main/plugins.js
@@ -197,7 +197,7 @@ exports.getFileIcon = (path) => new Promise((resolve, reject) => {
  */
 exports.connectItems = (items, plugin) => items.map((i) => {
   const icon = {
-    type: i.icon.type,
+    type: i && i.icon && i.icon.type,
     path: '',
   };
   if (i.icon && i.icon.path) {

--- a/app/renderer/src/components/ResultItem.js
+++ b/app/renderer/src/components/ResultItem.js
@@ -1,6 +1,6 @@
 import React, { PropTypes } from 'react';
 import { style, compose, hover } from 'glamor';
-import Icon from './Icon';
+import IconContainer from '../containers/IconContainer';
 import { ResultItemSchema, ThemeSchema } from '../schema';
 
 const activeStyle = {
@@ -111,7 +111,7 @@ const ResultItem = ({ theme, selected, item, isAltMod, isSuperMod, onDoubleClick
   return (
     <li {...compose(base, themeBase, themeHover, themeSelected)} onDoubleClick={onDoubleClick}>
       <div {...icon}>
-        <Icon icon={item.icon} />
+        <IconContainer icon={item.icon} />
       </div>
       <div {...details}>
         <h2 {...compose(title, theme.resultTitle || {})}>{item.title}</h2>

--- a/app/renderer/src/containers/IconContainer.js
+++ b/app/renderer/src/containers/IconContainer.js
@@ -1,0 +1,61 @@
+import { ipcRenderer } from 'electron';
+import React, { Component, PropTypes } from 'react';
+import Icon from '../components/Icon';
+import {
+  IPC_FETCH_ICON,
+  IPC_RETRIEVE_ICON,
+} from '../../../ipc';
+
+export default class IconContainer extends Component {
+  state = {
+    icon: {
+      type: 'text',
+      letter: '',
+      path: '',
+    },
+  };
+
+  fetchIcon = (evt, icon) => {
+    this.setState({
+      icon: {
+        type: 'file',
+        path: icon,
+      },
+    });
+  }
+
+  componentDidMount() {
+    if (this.props.icon.type === 'fileicon') {
+      ipcRenderer.send(IPC_FETCH_ICON, this.props.icon.path);
+      ipcRenderer.on(IPC_RETRIEVE_ICON, this.fetchIcon);
+    } else {
+      this.setState({ icon: this.props.icon });
+    }
+  }
+
+  componentWillUnmount() {
+    ipcRenderer.removeListener(IPC_RETRIEVE_ICON, this.fetchIcon);
+  }
+
+  render() {
+    return <Icon icon={this.state.icon} />;
+  }
+}
+
+IconContainer.defaultProps = {
+  icon: {
+    type: 'text',
+    path: '',
+    letter: '',
+    bgColor: '',
+  },
+};
+
+IconContainer.propTypes = {
+  icon: PropTypes.shape({
+    type: PropTypes.oneOf(['file', 'text', 'fileicon', '']),
+    path: PropTypes.string,
+    letter: PropTypes.string,
+    bgColor: PropTypes.string,
+  }),
+};

--- a/app/renderer/src/schema/ResultItemSchema.js
+++ b/app/renderer/src/schema/ResultItemSchema.js
@@ -14,7 +14,7 @@ export default PropTypes.shape({
 
   icon: PropTypes.shape({
     // The icon type
-    type: PropTypes.oneOf(['file', 'text', '']),
+    type: PropTypes.oneOf(['file', 'text', 'fileicon', '']),
     // The URL path to the icon.
     path: PropTypes.string,
     // If the type is "text", it will display this letter


### PR DESCRIPTION
This PR adds a new icon type called `fileicon` in the Plugins API. This makes use of the new native Electron `getFileIcon` API to retrieve a native filetype icon for a specified path.