### PR TITLE
fix: pass func down to `result-list-container`

### DIFF
--- a/app/renderer/src/components/App.js
+++ b/app/renderer/src/components/App.js
@@ -45,7 +45,13 @@ const App = props => {
           onChange={props.onQueryChange}
           onReset={props.onQueryReset}
         />
-        <ResultListContainer theme={props.theme} keys={props.keys} />
+        <ResultListContainer
+          theme={props.theme}
+          keys={props.keys}
+          onResetKeys={props.onResetKeys}
+          onSetActiveKey={props.onSetActiveKey}
+          onClearActiveKey={props.onClearActiveKey}
+        />
       </div>
     </div>
   );
@@ -58,8 +64,11 @@ App.defaultProps = {
 };
 
 App.propTypes = {
-  onQueryChange: PropTypes.func,
-  onQueryReset: PropTypes.func,
+  onQueryChange: PropTypes.func.isRequired,
+  onQueryReset: PropTypes.func.isRequired,
+  onSetActiveKey: PropTypes.func.isRequired,
+  onClearActiveKey: PropTypes.func.isRequired,
+  onResetKeys: PropTypes.func.isRequired,
   q: PropTypes.string,
   theme: ThemeSchema,
   keys: PropTypes.arrayOf(PropTypes.string),

--- a/app/renderer/src/containers/AppContainer.js
+++ b/app/renderer/src/containers/AppContainer.js
@@ -82,11 +82,11 @@ const AppContainer = class extends Component {
         q={this.state.query}
         theme={this.state.theme}
         keys={this.state.keys}
+        onClearActiveKey={this.clearActiveKey}
+        onSetActiveKey={this.setActiveKey}
+        onResetKeys={this.resetKeys}
         onQueryChange={this.updateQuery}
         onQueryReset={this.resetQuery}
-        onSetActiveKey={this.setActiveKey}
-        onClearActiveKey={this.clearActiveKey}
-        onResetKeys={this.resetKeys}
       />
     );
   }


### PR DESCRIPTION
Looks like I found some bugs.
We should avoid optional props.

A new pattern I'm starting to see from migrating from redux is that we are prop-drilling.
It should be fine tho, since we don't have a "deep" component tree within dext.
